### PR TITLE
Added brackets to array pop in the constructor

### DIFF
--- a/lib/bktree.js
+++ b/lib/bktree.js
@@ -37,7 +37,7 @@ var levenshtein = (function () {
 
 function bktree (term) {
   if (term instanceof Array) {
-    var tree = new bktree(term.pop);
+    var tree = new bktree(term.pop());
     tree.addTerms(term);
     return tree;
   }


### PR DESCRIPTION
Constructor param `term` is popped using pop method but missed the brackets which resulted in adding the pop method to the tree. Fixed it by added the parenthesis.  